### PR TITLE
Add option to disable the AMP Cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addPlugin(ampPlugin, {
     // Disable AMP validation (enabled by default)
     validation: false,
+    // Disable AMP Cache (enabled by default) 
+    ampCache: false,
     // Disable CSS minification (enabled by default)
     minifyCss: false,
     // For customizing the location of images assets, pass either a directory 

--- a/src/.eleventy.js
+++ b/src/.eleventy.js
@@ -15,6 +15,7 @@
  */
 
 const addAmpTransform = require('./transforms/ampTransform');
+const addDisableCacheTransform = require('./transforms/ampdisableCacheTransform');
 const addAmpValidation = require('./transforms/ampValidation');
 const addShortCodes = require('./shortcodes');
 
@@ -22,6 +23,7 @@ module.exports = {
   configFunction: (eleventyConfig, options) => {
     addAmpTransform(eleventyConfig, options);
     addAmpValidation(eleventyConfig, options);
+    addDisableCacheTransform(eleventyConfig, options);
     addShortCodes(eleventyConfig, options);
   },
 };

--- a/src/transforms/ampDisableCacheTransform.js
+++ b/src/transforms/ampDisableCacheTransform.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const AmpOptimizer = require('@ampproject/toolbox-optimizer');
+
+/**
+ * Removes the `amp` attribute from the `html` tag to disable serving
+ * the page from the AMP Cache. We do this in a separate transformer
+ * to still support AMP validation.
+ */
+const ampDisableCacheTransform = (eleventyConfig, options = {}) => {
+  if (options.ampCache !== false) {
+    return;
+  }
+  const ampOptimizer = AmpOptimizer.create({
+    transformations: ['RemoveAmpAttribute'],
+  });
+  eleventyConfig.addTransform('amp-disable-cache', async (content, outputPath) => {
+    if (!outputPath.endsWith('.html')) {
+      return content;
+    }
+    const amphtml = await ampOptimizer.transformHtml(content, {
+      outputPath,
+    });
+    return amphtml;
+  });
+};
+
+module.exports = ampDisableCacheTransform;

--- a/src/transforms/ampDisableCacheTransform.test.js
+++ b/src/transforms/ampDisableCacheTransform.test.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const ampDisableCacheTransform = require('./ampDisableCacheTransform');
+
+let key;
+let transform;
+
+let testConfig;
+
+beforeEach(() => {
+  testConfig = {
+    addTransform: (k, t) => {
+      key = k;
+      transform = t;
+    },
+  };
+});
+
+test('disabled by default', async () => {
+  ampDisableCacheTransform(testConfig);
+  const content = '<html amp></html>';
+  expect(transform).toBe(undefined);
+});
+
+test('removes the `amp` attribute', async () => {
+  ampDisableCacheTransform(testConfig, {ampCache: false});
+  const content = '<html amp></html>';
+  const transformedContent = await transform(content, 'test.html');
+  expect(transformedContent).toEqual('<html></html>');
+});
+
+test('removes the `⚡` attribute', async () => {
+  ampDisableCacheTransform(testConfig, {ampCache: false});
+  const content = '<html ⚡></html>';
+  const transformedContent = await transform(content, 'test.html');
+  expect(transformedContent).toEqual('<html></html>');
+});

--- a/src/transforms/ampValidation.js
+++ b/src/transforms/ampValidation.js
@@ -17,7 +17,7 @@
 const toolboxLog = require('@ampproject/toolbox-core').log.tag('AMP Validation');
 const amphtmlValidator = require('amphtml-validator');
 
-const ampValidationTransforom = (eleventyConfig, options = {}) => {
+const ampValidationTransform = (eleventyConfig, options = {}) => {
   if (options.validation === false) {
     return;
   }
@@ -54,4 +54,4 @@ function createErrorMessage(error, outputPath) {
   return msg;
 }
 
-module.exports = ampValidationTransforom;
+module.exports = ampValidationTransform;


### PR DESCRIPTION
This adds a transform that runs after validation which removes the `amp`
attribute resulting in the page not being added to the AMP cache.