### PR TITLE
add option to only process files that match a filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ module.exports = function(eleventyConfig) {
     imageBasePath: `${__dirname}/img`,
     // ... or a function that returns the correct path based on img src and outputPath.
     imageBasePath: (imageSrc, outputPath) => `${outputPath}/../img`,
+    // only process files that match a regex
+    filter: /^.*amp.*$/
   });
 };
 ```

--- a/src/.eleventy.js
+++ b/src/.eleventy.js
@@ -20,7 +20,7 @@ const addAmpValidation = require('./transforms/ampValidation');
 const addShortCodes = require('./shortcodes');
 
 module.exports = {
-  configFunction: (eleventyConfig, options) => {
+  configFunction: (eleventyConfig, providedOptions) => {
     addAmpTransform(eleventyConfig, options);
     addAmpValidation(eleventyConfig, options);
     addDisableCacheTransform(eleventyConfig, options);

--- a/src/helpers/processOptions.js
+++ b/src/helpers/processOptions.js
@@ -1,0 +1,17 @@
+const processOptions = (providedOptions) => {
+  const defaultOptions = {
+    filter: /.*/
+  }
+
+  const options = Object.assign(defaultOptions, providedOptions)
+
+  try {
+    options.filter = new RegExp(options.filter)
+  } catch (e) {
+    throw new Error(`filter needs to be a valid RegExp, provided : ${options.filter}`)
+  }
+
+  return options
+}
+
+module.exports = processOptions

--- a/src/transforms/ampTransform.js
+++ b/src/transforms/ampTransform.js
@@ -16,11 +16,15 @@
 
 const AmpOptimizer = require('@ampproject/toolbox-optimizer');
 const collectCss = require('../helpers/collectCss');
+const processOptions = require('../helpers/processOptions');
 
-const ampTransform = (eleventyConfig, options = {}) => {
+const ampTransform = (eleventyConfig, providedOptions = {}) => {
+
+  const options = processOptions(providedOptions);
+
   const ampOptimizer = createAmpOptimizer(options);
   eleventyConfig.addTransform('amp', async (content, outputPath) => {
-    if (!outputPath.endsWith('.html')) {
+    if (!outputPath.endsWith('.html') || !options.filter.test(outputPath)) {
       return content;
     }
     const amphtml = await ampOptimizer.transformHtml(content, {

--- a/src/transforms/ampTransform.test.js
+++ b/src/transforms/ampTransform.test.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const ampTransformer = require('./ampTransform');
+let ampTransformer = require('./ampTransform');
 
 let key;
 let transform;
@@ -42,4 +42,16 @@ test('transforms html files', async () => {
   const content = '<h1>Hello World</h1>';
   const transformedContent = await transform(content, 'test.html');
   expect(transformedContent).toContain('<html');
+});
+
+test('only runs on files that match filter, when provided', async () => {
+
+  // should only match filenames that contain "amp"
+  ampTransformer(testConfig, {filter: /^.*amp.*$/});
+
+  const content = '<h1>Hello World</h1>';
+  const unmatchedTransformedContent = await transform(content, 'test.html');
+  const matchedTransformedContent = await transform(content, 'test.amp.html');
+  expect(unmatchedTransformedContent).toBe(content);
+  expect(matchedTransformedContent).toContain('<html');
 });

--- a/src/transforms/ampValidation.js
+++ b/src/transforms/ampValidation.js
@@ -16,14 +16,18 @@
 
 const toolboxLog = require('@ampproject/toolbox-core').log.tag('AMP Validation');
 const amphtmlValidator = require('amphtml-validator');
+const processOptions = require('../helpers/processOptions')
 
-const ampValidationTransform = (eleventyConfig, options = {}) => {
+const ampValidationTransform = (eleventyConfig, providedOptions = {}) => {
+
+  const options = processOptions(providedOptions);
+
   if (options.validation === false) {
     return;
   }
   const log = options.log || toolboxLog;
   eleventyConfig.addTransform('amp-validation', async (content, outputPath) => {
-    if (!outputPath.endsWith('.html')) {
+    if (!outputPath.endsWith('.html') || !options.filter.test(outputPath)) {
       return content;
     }
     const result = await validate(content);


### PR DESCRIPTION
fixes #10

@sebastianbenz I opted to merge the options object to avoid doing an existence check. Feels weird to have duplicate code in two places, so if you have an opinion on how it should be modularized or replaced, let me know.