### PR TITLE
fix(ref-error): options not defined in .eleventy.js

### DIFF
--- a/src/.eleventy.test.js
+++ b/src/.eleventy.test.js
@@ -14,16 +14,10 @@
  * limitations under the License.
  */
 
-const addAmpTransform = require('./transforms/ampTransform');
-const addDisableCacheTransform = require('./transforms/ampdisableCacheTransform');
-const addAmpValidation = require('./transforms/ampValidation');
-const addShortCodes = require('./shortcodes');
+const {configFunction} = require('./.eleventy.js');
+// load the default eleventy configuration handler
+const eleventyConfig = require('@11ty/eleventy/src/EleventyConfig');
 
-module.exports = {
-  configFunction: (eleventyConfig, options) => {
-    addAmpTransform(eleventyConfig, options);
-    addAmpValidation(eleventyConfig, options);
-    addDisableCacheTransform(eleventyConfig, options);
-    addShortCodes(eleventyConfig, options);
-  },
-};
+test('has a valid configuration function', () => {
+  expect(() => configFunction(eleventyConfig)).not.toThrow();
+});


### PR DESCRIPTION
The PR #13 introduced this issue by changing the
function argument name but not changing it
on all usages

Fixes #21