### PR TITLE
Avoid modifying outputDir

### DIFF
--- a/src/helpers/ImageOptimizer.js
+++ b/src/helpers/ImageOptimizer.js
@@ -56,7 +56,6 @@ const createImageOptimizer = (globalOpts) => {
       if (!isAbsoluteUrl(src)) {
         src = resolveImageOnFileSystem(globalOpts, src);
       }
-      opts.outputDir = path.join(opts.outputDir, opts.urlPath);
       const stats = await Image(src, opts);
       const srcForWidth = stats[format][0].url;
       return srcForWidth;


### PR DESCRIPTION
I think this line should be removed. (It was added via #31.)

I think the cached images should be created directly in `outputDir` rather than `${outputDir}/${urlPath}`, both for semantic reasons and also because this is how it's documented in the [eleventy-img config](https://www.npmjs.com/package/@11ty/eleventy-img#options-list).