### PR TITLE
Re-structure self-hosting options

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,18 +225,20 @@ Optionally pass in an options object as the second argument to `addPlugin` to fu
 const ampPlugin = require('@ampproject/eleventy-plugin-amp');
 module.exports = function (eleventyConfig) {
   eleventyConfig.addPlugin(ampPlugin, {
-    // Disable AMP Cache (enabled by default) and self-host the AMP runtime.
+    // Disable AMP Cache (enabled by default)
     ampCache: false,
+    // The host where the AMP runtime is being served from, the default is cdn.ampproject.org.
+    ampRuntimeHost: 'https://example.com',
     // The optional target dir as configured in `dir.output`. Required for image optimization
     // and AMP runtime self-hosting. Defaults to `_site`.
     // See https://www.11ty.dev/docs/config/#output-directory
     dir: {
       output: 'dist',
     }
+    // Download the AMP Runtime, default is false. Requires dir.output and ampRuntimeHost.
+    downloadAmpRuntime: true,
     // Only process files that match a regex.
     filter: /^.*amp.*$/,
-    // The host where the site is being served from, required for self-hosting the AMP runtime.
-    host: 'https://example.com',
     // Image support in Markdown files might require customizing the location of images assets, pass either a directory.
     imageBasePath: `${__dirname}/img`,
     // ... or a function that returns the correct path based on img src and outputPath.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/ampproject/eleventy-plugin-amp.git"
   },
   "files": [
-    "src"
+    "src/**/!(*.test.js)*"
   ],
   "scripts": {
     "changelog": "lerna-changelog",

--- a/src/helpers/AmpConfig.js
+++ b/src/helpers/AmpConfig.js
@@ -1,15 +1,25 @@
 const path = require('path');
 const ImageOptimizer = require('./ImageOptimizer');
+const AmpOptimizer = require('@ampproject/toolbox-optimizer');
+const collectCss = require('../helpers/collectCss');
 
 const AmpConfig = (providedOptions) => {
   const defaultOptions = {
-    filter: /.*/,
-    optimizeImages: true,
     dir: {
       output: '_site',
     },
+    filter: /.*/,
+    optimizeImages: true,
     pathPrefix: '',
     workingDir: path.resolve('.'),
+    // support the markdown image syntax
+    markdown: true,
+    // add CSS collector
+    transformations: [
+      collectCss,
+      // allow custom transformations via options
+      ...(providedOptions.transformations || AmpOptimizer.TRANSFORMATIONS_AMP_FIRST),
+    ],
   };
 
   const options = Object.assign(defaultOptions, providedOptions);

--- a/src/transforms/ampDisableCacheTransform.js
+++ b/src/transforms/ampDisableCacheTransform.js
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 const AmpOptimizer = require('@ampproject/toolbox-optimizer');
-const fetchRuntime = require('@ampproject/toolbox-runtime-fetch');
 const AmpConfig = require('../helpers/AmpConfig');
-const fs = require('fs');
-const path = require('path');
 const {hasAttribute, firstChildByTag} = require('@ampproject/toolbox-optimizer/lib/NodeUtils');
 
 /**
@@ -29,100 +26,22 @@ const {hasAttribute, firstChildByTag} = require('@ampproject/toolbox-optimizer/l
  * Note: amp-geo won't work in this mode as it's an AMP Cache feature.
  * See https://github.com/ampproject/amphtml/blob/master/spec/amp-framework-hosting.md#amp-geo-fallback-api
  */
-const ampDisableCacheTransform = async (eleventyConfig, providedOptions = {}) => {
+const ampDisableCacheTransform = (eleventyConfig, providedOptions = {}) => {
   const options = AmpConfig(providedOptions);
-  const availableRuntimes = new Set();
-
   if (options.ampCache !== false) {
     return;
   }
 
-  /**
-   * A custom transformer that detects the used AMP runtime version and triggers the AMP runtime download.
-   */
-  class DownloadRuntime {
-    constructor(config) {
-      this.log = config.log;
-      if (!options.host) {
-        this.log.warn('Cannot self-host the AMP runtime as `host` option is not specified.');
-      }
-    }
-    async transform(root, params) {
-      if (!options.host) {
-        // host needs to be specified to be able to self-host the AMP runtime
-        return;
-      }
-      const outputDir = options.dir.output;
-      const html = firstChildByTag(root, 'html');
-      const head = firstChildByTag(html, 'head');
-      for (const node of head.children) {
-        if (node.tagName !== 'style') {
-          continue;
-        }
-        if (!hasAttribute(node, 'amp-runtime')) {
-          continue;
-        }
-        const ampRuntimeVersion = node.attribs['i-amphtml-version'];
-        if (!ampRuntimeVersion) {
-          continue;
-        }
-
-        const ampUrlPrefix = path.join('/rtv', ampRuntimeVersion);
-        const downloadSuccess = await this.downloadRuntime(
-          ampRuntimeVersion,
-          outputDir,
-          ampUrlPrefix
-        );
-        if (!downloadSuccess) {
-          this.log.warn('Failed downloading AMP runtime.');
-          return;
-        }
-        // Runtime has been successfully downloaded, update params
-        // to rewrite the script import URLs in subsequent transformations
-        params.ampRuntimeVersion = ampRuntimeVersion;
-        params.ampUrlPrefix = new URL(
-          path.join(options.pathPrefix, ampUrlPrefix),
-          options.host
-        ).toString();
-      }
-    }
-
-    async downloadRuntime(ampRuntimeVersion, ouputDir, ampUrlPrefix) {
-      if (availableRuntimes.has(ampRuntimeVersion)) {
-        return true;
-      }
-      const targetDir = path.join(ouputDir, ampUrlPrefix);
-      if (fs.existsSync(targetDir)) {
-        availableRuntimes.add(ampRuntimeVersion);
-        return true;
-      }
-      // Create dir to avoid triggering multiple downloads
-      fs.mkdirSync(targetDir, {recursive: true});
-      const status = fetchRuntime.getRuntime({
-        rtv: ampRuntimeVersion,
-        dest: ouputDir,
-      }).status;
-      if (status) {
-        availableRuntimes.add(ampRuntimeVersion);
-      }
-      return status;
-    }
-  }
-
   const ampOptimizer = AmpOptimizer.create({
-    transformations: [DownloadRuntime, 'RemoveAmpAttribute', 'RewriteAmpUrls'],
+    transformations: ['RemoveAmpAttribute'],
   });
-  eleventyConfig.addTransform('amp-disable-cache', async (content, outputPath) => {
+  eleventyConfig.addTransform('amp-disable-cache', (content, outputPath) => {
     if (!options.isAmp(outputPath)) {
       return content;
     }
-    const amphtml = await ampOptimizer.transformHtml(content, {
+    return ampOptimizer.transformHtml(content, {
       outputPath,
-      ampRuntimeStyles: '',
-      // it's OK to enable ESM as we're publishing invalid AMP anyway (this will be valid AMP in the future)
-      experimentEsm: true,
     });
-    return amphtml;
   });
 };
 


### PR DESCRIPTION
* Separate runtime download from ampCache: false option. Positive
sideffect is that the implementation got a lot easier.
* Introduce new option `downloadAmpRuntime` to explicitly enable AMP
self hosting.
* Rename `host` option to `ampRuntimeHost`.