### PR TITLE
fix: fixed typo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/eleventy-plugin-amp",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/helpers/ImageOptimizer.js
+++ b/src/helpers/ImageOptimizer.js
@@ -20,7 +20,7 @@ const Image = require('@11ty/eleventy-img');
 const AmpConfig = require('./AmpConfig');
 
 const SUPPORTED_FORMATS = new Set([
-  'afiv',
+  'avif',
   'heic',
   'heif',
   'jpeg',


### PR DESCRIPTION
This PR fixes a typo introduced in https://github.com/ampproject/eleventy-plugin-amp/commit/f695ef9f1546a982672d6d4135c15d04adc59f45.

Now the `SUPPORTED_FORMATS` Set contains `avif` instead of `afiv`.